### PR TITLE
don't use startup file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAKEFILE:=$(abspath $(firstword $(MAKEFILE_LIST)))
 SRCDIR:=$(shell dirname $(abspath $(firstword $(MAKEFILE_LIST))))
-JULIA ?= julia
+JULIA ?= julia --startup-file=no
 # PREFIX ?= ${SRCDIR}/build
 YGGBINDIR ?= ${SRCDIR}/build/bin
 


### PR DESCRIPTION
fix error in case user have `using Revise, Debugger` inside `startup.jl`