### PR TITLE
Add clang/clang++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ $(eval $(call simple-install,zstd,Zstd_jll,zstd))
 $(eval $(call simple-install,zstdmt,Zstd_jll,zstdmt))
 $(eval $(call simple-install,rclone,Rclone_jll,rclone))
 $(eval $(call simple-install,node,NodeJS_16_jll,node))
+$(eval $(call simple-install,clang,Clang_jll,clang))
+$(eval $(call simple-install,clang++,Clang_jll,clang))
 
 ### Poppler-utils
 $(eval $(call simple-install,pdfattach,Poppler_jll,pdfattach))

--- a/generate_shims.jl
+++ b/generate_shims.jl
@@ -47,14 +47,12 @@ end
 
 exepath, env = split(strip(read(`$(Base.julia_cmd()) -e $code`, String)), '\n')
 
-@assert basename(exepath) == binary
-
-shimpath = joinpath(yggbindir, basename(exepath))
+shimpath = joinpath(yggbindir, binary)
 mkpath(dirname(shimpath))
 open(shimpath, "w") do io
     print(io, """
         #!/bin/bash
-        exec env $(env) $(basename(exepath)) "\$@"
+        $(env) exec -a "\$0" $(basename(exepath)) "\$@"
         """)
 end
 


### PR DESCRIPTION
These are the same binary, but clang will select which one to use
depending on the filename of the invocation. This requires two
adjustments.

1. Remove the assertion that the binaryname (clang++) and the basename
   of the executable (clang) need to be the same, since that is not
   the case here.

2. Use `exec -a` to make sure to preserve the binaryname even through the
   exec so clang knows that the bash script was originally called `clang++`
   and can properly select the C++ driver mode.